### PR TITLE
Building on Ubuntu-20.04 HWE

### DIFF
--- a/README-compile.md
+++ b/README-compile.md
@@ -24,10 +24,10 @@
   apt-get install g++ cmake make qtbase5-dev libqt5sql5-sqlite \
    uuid-dev libcap-dev uuid-runtime linux-headers-generic dkms
   ~~~
-  Ubuntu 20.04 HWE:
+  Ubuntu HWE:
   ~~~
   apt-get install g++ cmake make qtbase5-dev libqt5sql5-sqlite \
-   uuid-dev libcap-dev uuid-runtime linux-headers-generic-hwe-20.04 dkms
+   uuid-dev libcap-dev uuid-runtime linux-headers-generic-hwe-$(lsb_release -rs) dkms
   ~~~
   Opensuse:
   ~~~

--- a/README-compile.md
+++ b/README-compile.md
@@ -24,6 +24,11 @@
   apt-get install g++ cmake make qtbase5-dev libqt5sql5-sqlite \
    uuid-dev libcap-dev uuid-runtime linux-headers-generic dkms
   ~~~
+  Ubuntu 20.04 HWE:
+  ~~~
+  apt-get install g++ cmake make qtbase5-dev libqt5sql5-sqlite \
+   uuid-dev libcap-dev uuid-runtime linux-headers-generic-hwe-20.04 dkms
+  ~~~
   Opensuse:
   ~~~
   zypper install gcc-c++ cmake make libqt5-qtbase-devel \

--- a/kernel/cmake/FindKernelHeaders.cmake
+++ b/kernel/cmake/FindKernelHeaders.cmake
@@ -6,12 +6,14 @@ execute_process(
         OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 string(REGEX REPLACE "-[^-]+$" "" KERNEL_RELEASE_NO_ARCH ${KERNEL_RELEASE})
+string(REGEX REPLACE "^([0-9]+\.[0-9]+).*$" "\\1" KERNEL_RELEASE_HWE ${KERNEL_RELEASE})
 
 # Find the headers
 foreach(header_path
         /usr/src/linux-headers-${KERNEL_RELEASE_NO_ARCH}-common # Debian
         /usr/src/linux-${KERNEL_RELEASE_NO_ARCH}/include        # Opensuse
         /usr/src/linux-headers-${KERNEL_RELEASE_NO_ARCH}        # Ubuntu
+	/usr/src/linux-hwe-${KERNEL_RELEASE_HWE}-headers-${KERNEL_RELEASE_NO_ARCH}        # Ubuntu HWE
         )
     if(EXISTS "${header_path}")
         set(KERNELHEADERS_DIR "${header_path}")


### PR DESCRIPTION
This PR relates to issue #7.
I'm not sure if fixing this makes too much sense.
It bloats the file README-compile.md quite a bit.

For me personally, it helps by not having to install
additional header files for the non-hwe kernel on
my desktop.

Feel free to reject the PR. I will not feel offended by this.