### PR TITLE
Avoid compile-time constant PAGE_SIZE not available on ARM

### DIFF
--- a/src/shournal-run/mark_helper.cpp
+++ b/src/shournal-run/mark_helper.cpp
@@ -3,6 +3,7 @@
 #include <sys/user.h>
 #include <QHash>
 #include <QVersionNumber>
+#include <unistd.h>
 
 #include "app.h"
 #include "shournalk_ctrl.h"
@@ -204,12 +205,13 @@ void ShournalkControl::markPaths(const Settings::StrLightSet& paths, int path_tp
 void ShournalkControl::markExtensions
 (const Settings::StrLightSet& extensions, int ext_type){
     StrLight extBuf;
-    extBuf.reserve(PAGE_SIZE);
+    const auto page_size = sysconf(_SC_PAGESIZE);
+    extBuf.reserve(page_size);
     for(const auto & str : extensions){
         // add extensions to a single long string
         // separated by slash. Flush, if bigger
         // than PAGE_SIZE (unlikely)
-        if(extBuf.size() + str.size() + 1 > PAGE_SIZE){
+        if(extBuf.size() + str.size() + 1 > page_size){
             doMarkExtensions(extBuf, ext_type);
         }
         extBuf += str + '/';
@@ -233,5 +235,3 @@ void ShournalkControl::doMarkExtensions
                            .arg(extensions.c_str()));
     }
 }
-
-

--- a/src/shournal-run/mark_helper.cpp
+++ b/src/shournal-run/mark_helper.cpp
@@ -205,13 +205,13 @@ void ShournalkControl::markPaths(const Settings::StrLightSet& paths, int path_tp
 void ShournalkControl::markExtensions
 (const Settings::StrLightSet& extensions, int ext_type){
     StrLight extBuf;
-    const auto page_size = sysconf(_SC_PAGESIZE);
-    extBuf.reserve(page_size);
+    const StrLight::size_type BUF_SIZE = 4096;
+    extBuf.reserve(BUF_SIZE);
     for(const auto & str : extensions){
         // add extensions to a single long string
         // separated by slash. Flush, if bigger
-        // than PAGE_SIZE (unlikely)
-        if(extBuf.size() + str.size() + 1 > page_size){
+        // than BUF_SIZE (unlikely)
+        if(extBuf.size() + str.size() + 1 > BUF_SIZE){
             doMarkExtensions(extBuf, ext_type);
         }
         extBuf += str + '/';


### PR DESCRIPTION
!! Not really tested, might only want to retrieve it once. !!

I wanted to test shournal under Linux ARM in a virtual machine on Mac OS. And I ran into a compile error that PAGE_SIZE wasn't found.

This is my devcontainer:

https://github.com/kolloch/zack/tree/main/.devcontainer